### PR TITLE
Fix smooth scrolling code body->documentElement

### DIFF
--- a/styleguide/src/js/main.js
+++ b/styleguide/src/js/main.js
@@ -102,9 +102,9 @@ document.querySelector('.cd-nav-trigger').addEventListener('click', function() {
   document.querySelector('header').classList.toggle('nav-is-visible');
 });
 // smooth scroll to the selected section
-  // document.querySelectorAll('.cd-main-nav a[href^="#"]').forEach(function(link) {
-  // link.addEventListener('click', function(event) {
-  //   event.preventDefault();
+document.querySelectorAll('.cd-main-nav a[href^="#"]').forEach(function(link) {
+    link.addEventListener('click', function(event) {
+    event.preventDefault();
     const header = document.querySelector('header');
     header.classList.remove('nav-is-visible');
     const target = document.querySelector(this.hash),
@@ -113,12 +113,12 @@ document.querySelector('.cd-nav-trigger').addEventListener('click', function() {
         .marginTop.replace('px', ''),
       headerHeight = header.scrollHeight;
     scrollTo(
-      document.body,
+      document.documentElement,
       parseInt(target.offsetTop - headerHeight - topMargin),
       200
     );
-  // });
-// });
+  });
+});
 
 function scrollTo(element, to, duration) {
   if (duration <= 0) return;


### PR DESCRIPTION
Instead of document.body, used document.documentElement in the first scrollTo() call.  This fixed the smooth scrolling.