### PR TITLE
inverted to small view/fixed text-image overlap

### DIFF
--- a/scss/partials/_basic-style.scss
+++ b/scss/partials/_basic-style.scss
@@ -28,13 +28,14 @@ a {
 }
 
 .page-wrapper {
+    @include MQ(L){
     display:grid;
     grid-gap: 1em;
     grid-template-columns: 1fr 2fr 1fr;
     grid-template-rows: repeat(3, auto);
     position: relative; 
-
-    @include MQ(S) {
-        display: block;
     }
+    // @include MQ(S) {
+    //     display: block;
+    // }
 }

--- a/scss/partials/_footer.scss
+++ b/scss/partials/_footer.scss
@@ -6,25 +6,32 @@ footer {
     background-color: lighten($dark-jungle-green, 15%);
 
     a {
-        width: 4em;
-        height: 4em;
-        padding: 1.75em 0;
+        width: 3em;
+        height: 3em;
         margin: 0 .5em;
-        @include MQ(S) {
-            width: 3em;
-            height: 3em;
-            margin: 0 .5em;
-        }
+        color: lighten(rgba(255, 255, 255, 0.5), 50%);
         display: inline-block;
         overflow: hidden;
-        position: relative;
-        color: lighten(rgba(255, 255, 255, 0.5), 50%);
+        @include MQ(L) {
+            width: 4em;
+            height: 4em;
+            padding: 1.75em 0;
+            margin: 0 .5em;
+            // display: inline-block;
+            // overflow: hidden;
+            position: relative;
+        }
+        // @include MQ(S) {
+        //     width: 3em;
+        //     height: 3em;
+        //     margin: 0 .5em;
+        // }
         
         &::before {
+            font-size: 3em;
             font-family: $footer-font;
-            font-size: 4em;
-            @include MQ(S) {
-                font-size: 3em;
+            @include MQ(L) {
+                font-size: 4em;
             }
         }
     }
@@ -34,11 +41,11 @@ footer {
     }
     
     .zen-validate-css::before {
-        content: "3";
+       content: "3";
     }
     
     .zen-license::before {
-        content: "c";
+       content: "c";
     }
     
     .zen-accessibility::before {

--- a/scss/partials/_intro.scss
+++ b/scss/partials/_intro.scss
@@ -1,49 +1,55 @@
 // Put intro elements here.
 
 .intro {
+    @include MQ(L) {
     grid-column: 2/3;
     display: block;
     grid-row: 1/2; 
+    }
 }
 
-//Image1
+//Image1---top image
 .intro::after {
-    content: url('jellyfish-svg');
-    position: absolute;
-    top: 12.5em;
-    left: 0;
-    display: block;
-    width: 20%;
-    height: 25em;
-    border: .5em solid $teal;
-
-    @include MQ(S) {
-        display: none;  // TODO: Put semi-transparent jellyfish graphic behind text.
+    display: none; 
+    @include MQ(L) {
+        content: url('jellyfish-svg');
+        position: absolute;
+        top: 12.5em;
+        left: 0;
+        display: block;
+        width: 20%;
+        height: 25em;
+        border: .5em solid $teal;
     }
+    // @include MQ(S) {
+    //     display: none;  // TODO: Put semi-transparent jellyfish graphic behind text.
+    // }
 }
 
 
 .summary {
+    position: static;
+    //width: 100%;
     display: block;
-    position: absolute;
-    top: 37em;
-    left: 0;
-    width: 22%;
-    
-    @include MQ(S) {
-        position: static;
-        width: 100%;
+    @include MQ(L) {
+        // position: static;
+        // width: 100%;
+        position: absolute;
+        top: 37em;
+        left: 0;
+        width: 22%;
     }
 }
 
 
 .preamble {
     display: block;
-    padding-top: 7em;
-
-    @include MQ(S) {
-        padding-top: 0;
+    @include MQ(L) {
+        padding-top: 5em;
     }
+    // @include MQ(S) {
+    //     padding-top: 0;
+    // }
 }
 
 .preamble > h3::before {

--- a/scss/partials/_layout.scss
+++ b/scss/partials/_layout.scss
@@ -1,20 +1,20 @@
 // breakpoints
    
-$S:     768px;   
-$M:     1024px;     
-$L:     1600px;   
+// $S:     768px;   
+// $M:     1024px;     
+$L:     900px;   
 
 // media queries
 
 @mixin MQ($canvas) {
-  @if $canvas == S {
-   @media only screen and (max-width: $S) { @content; } 
-  }
-  @else if $canvas == M {
-   @media only screen and ((min-width: $S) and (max-width: $M)) { @content; } 
-  }
-  @else if $canvas == L {
-   @media only screen and ((min-width: $M) and (max-width: $L)) { @content; } 
+  // @if $canvas == S {
+  //  @media only screen and (max-width: $S) { @content; } 
+  // }
+  // @else if $canvas == M {
+  //  @media only screen and ((min-width: $S) and (max-width: $M)) { @content; } 
+  // }
+  @if $canvas == L {
+   @media only screen and (min-width: $L) { @content; } 
   }
 }
 

--- a/scss/partials/_main.scss
+++ b/scss/partials/_main.scss
@@ -18,28 +18,26 @@
 */
 
 .main{   
-    display: grid;
     grid-column:  1 / span 3;
     grid-row: 2/3;
 }
 
 
-
-//image2
+//image2--bottom image
 .participation::before{
+    @include MQ(L) {
     content: url('jellyfish-svg');
     position: absolute;
-    float: right;
-    top: 60em;
+    bottom: 11em;
     right: 0;
     display: block;
     width: 20%;
     height: 25em;
     border: .5em solid $teal;
-
-    @include MQ(S) {
-        display: none;      // TODO: Put semi-transparent jellyfish graphic behind text.
     }
+    // @include MQ(S) {
+    //     display: none;      // TODO: Put semi-transparent jellyfish graphic behind text.
+    // }
 }
 
 
@@ -57,12 +55,23 @@
 
 .explanation{
     display:block;
-    padding: 0 25%;
-
-    @include MQ(S) {
-        padding: 0;
+    //padding: 0 25%;
+    @include MQ(L) {
+        padding: 0 25%;
     }
 }
+
+.requirements{
+    display:block;
+    @include MQ(L) {
+        padding-right: 25%; 
+    }
+}
+
+
+.benefits{
+    display:block;
+}  
 
 .requirements p:last-of-type {
     text-align: center;

--- a/scss/partials/_sidebar.scss
+++ b/scss/partials/_sidebar.scss
@@ -3,18 +3,17 @@
 $sidebar-margin-sm: 1.5em;
 
 .sidebar {
-    padding-top: 10em;
-    display: grid;
-    grid-column: 3/4;
-    grid-row: 1/3;
-
-    @include MQ(S) {
-        display: block;
-        margin-left: $sidebar-margin-sm;
-        margin-right: $sidebar-margin-sm;
-        margin-bottom: $sidebar-margin-sm;
-        padding-top: 1em;
-        grid-column: 0;
-        grid-row: 0;
+    display: block;
+    margin-left: $sidebar-margin-sm;
+    margin-right: $sidebar-margin-sm;
+    margin-bottom: $sidebar-margin-sm;
+    padding-top: 1em;
+    // grid-column: 0;
+    // grid-row: 0;
+    @include MQ(L) {
+        padding-top: 10em;
+        // display: grid;
+        grid-column: 3/4;
+        grid-row: 1/3;
     }
 }


### PR DESCRIPTION
Here are the changes:
_layout--commented out S&M mixins.  Changed L to 900px and "min-width" only.

_Main--added requirement padding to prevent text and image overlapping.  Deleted an unnecessary "display:gird;".   Inverted "explanation" and image.

_basic-style--inverted "page-wrapper"

_footer--inverted links ("a") and "::before.

_intro--inverted image, "intro" and "preamble"

_sidebar--inverted and deleted unnecessary "grid: display".